### PR TITLE
Align uservices to use the uProtocol 1.5.8 spec's uoptions.proto updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <uprotocol-core-api.version>1.5.7</uprotocol-core-api.version>
+        <uprotocol-core-api.version>1.5.8</uprotocol-core-api.version>
         <proto-google-common-protos.version>2.16.0</proto-google-common-protos.version>
         <os-maven-plugin.version>1.6.0</os-maven-plugin.version>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>

--- a/src/main/proto/example/hello_world/v1/hello_world_service.proto
+++ b/src/main/proto/example/hello_world/v1/hello_world_service.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 // File options
 package example.hello_world.v1;
 
-import "uprotocol_options.proto";
+import "uoptions.proto";
 
 option java_package = "org.covesa.uservice.example.hello_world.v1";
 option java_multiple_files = true;
@@ -28,10 +28,10 @@ option java_multiple_files = true;
 service HelloWorld {
 
   // Service Metadata - Name, version, id, RPC methods
-  option (uprotocol.name) = "example.hello_world";
-  option (uprotocol.version_major) = 1;
-  option (uprotocol.version_minor) = 0;
-  option (uprotocol.id) = 999;
+  option (uprotocol.service_name) = "example.hello_world";
+  option (uprotocol.service_version_major) = 1;
+  option (uprotocol.service_version_minor) = 0;
+  option (uprotocol.service_id) = 999;
 
   // Say Hello method
   // The method URI is:

--- a/src/main/proto/example/hello_world/v1/hello_world_service.proto
+++ b/src/main/proto/example/hello_world/v1/hello_world_service.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 // File options
 package example.hello_world.v1;
 
-import "uoptions.proto";
+import "uprotocol/uoptions.proto";
 
 option java_package = "org.covesa.uservice.example.hello_world.v1";
 option java_multiple_files = true;

--- a/src/main/proto/vehicle/body/cabin_climate/v1/cabin_climate_service.proto
+++ b/src/main/proto/vehicle/body/cabin_climate/v1/cabin_climate_service.proto
@@ -20,7 +20,7 @@ package vehicle.body.cabin_climate.v1;
 
 import "google/protobuf/field_mask.proto";
 import "google/rpc/status.proto";
-import "uoptions.proto";
+import "uprotocol/uoptions.proto";
 import "vehicle/body/cabin_climate/v1/cabin_climate_properties.proto";
 import "vehicle/body/cabin_climate/v1/cabin_climate_topics.proto";
 

--- a/src/main/proto/vehicle/body/cabin_climate/v1/cabin_climate_service.proto
+++ b/src/main/proto/vehicle/body/cabin_climate/v1/cabin_climate_service.proto
@@ -20,7 +20,7 @@ package vehicle.body.cabin_climate.v1;
 
 import "google/protobuf/field_mask.proto";
 import "google/rpc/status.proto";
-import "uprotocol_options.proto";
+import "uoptions.proto";
 import "vehicle/body/cabin_climate/v1/cabin_climate_properties.proto";
 import "vehicle/body/cabin_climate/v1/cabin_climate_topics.proto";
 
@@ -32,10 +32,10 @@ option java_multiple_files = true;
 //
 service BodyCabinclimate {
   // Service meta-data option definitions - Name, version, id, rpc method
-  option (uprotocol.name) = "body.cabin_climate";
-  option (uprotocol.version_major) = 1;
-  option (uprotocol.version_minor) = 2;
-  option (uprotocol.id) = 5;
+  option (uprotocol.service_name) = "body.cabin_climate";
+  option (uprotocol.service_version_major) = 1;
+  option (uprotocol.service_version_minor) = 2;
+  option (uprotocol.service_id) = 5;
   option (number_of_row_1_zones) = 2;
   option (number_of_row_2_zones) = 0;
   option (number_of_row_3_zones) = 0;

--- a/src/main/proto/vehicle/body/horn/v1/horn_service.proto
+++ b/src/main/proto/vehicle/body/horn/v1/horn_service.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 package vehicle.body.horn.v1;
 
 import "google/rpc/status.proto";
-import "uprotocol_options.proto";
+import "uoptions.proto";
 import "vehicle/body/horn/v1/horn_topics.proto";
 
 option java_package = "org.covesa.uservice.vehicle.body.horn.v1";
@@ -30,10 +30,10 @@ option java_multiple_files = true;
 // commanding on/off time, number of cycles, or total sequences.
 service Horn {
   // Service Metadata - Name, version, id, rpc methods
-  option (uprotocol.name) = "body.horn";
-  option (uprotocol.version_major) = 1;
-  option (uprotocol.version_minor) = 1;
-  option (uprotocol.id) = 28;
+  option (uprotocol.service_name) = "body.horn";
+  option (uprotocol.service_version_major) = 1;
+  option (uprotocol.service_version_minor) = 1;
+  option (uprotocol.service_id) = 28;
 
   // Activate Horn resource
   rpc ActivateHorn(ActivateHornRequest) returns (ActivateHornResponse) {

--- a/src/main/proto/vehicle/body/horn/v1/horn_service.proto
+++ b/src/main/proto/vehicle/body/horn/v1/horn_service.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 package vehicle.body.horn.v1;
 
 import "google/rpc/status.proto";
-import "uoptions.proto";
+import "uprotocol/uoptions.proto";
 import "vehicle/body/horn/v1/horn_topics.proto";
 
 option java_package = "org.covesa.uservice.vehicle.body.horn.v1";

--- a/src/main/proto/vehicle/body/mirrors/v1/mirrors_service.proto
+++ b/src/main/proto/vehicle/body/mirrors/v1/mirrors_service.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 package vehicle.body.mirrors.v1;
 
 import "google/rpc/status.proto";
-import "uprotocol_options.proto";
+import "uoptions.proto";
 import "uservices_options.proto";
 import "vehicle/body/mirrors/v1/mirrors_properties.proto";
 import "vehicle/body/mirrors/v1/mirrors_topics.proto";
@@ -31,10 +31,10 @@ option java_multiple_files = true;
 // Provides the ability to command side mirrors
 service BodyMirrors {
   // Service Metadata
-  option (uprotocol.name) = "body.mirrors";
-  option (uprotocol.version_major) = 1;
-  option (uprotocol.version_minor) = 0;
-  option (uprotocol.id) = 37;
+  option (uprotocol.service_name) = "body.mirrors";
+  option (uprotocol.service_version_major) = 1;
+  option (uprotocol.service_version_minor) = 0;
+  option (uprotocol.service_id) = 37;
 
   // If the value of is_power_side_mirror_present is FALSE, then any RPC invoked
   // will respond with '14'

--- a/src/main/proto/vehicle/body/mirrors/v1/mirrors_service.proto
+++ b/src/main/proto/vehicle/body/mirrors/v1/mirrors_service.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 package vehicle.body.mirrors.v1;
 
 import "google/rpc/status.proto";
-import "uoptions.proto";
+import "uprotocol/uoptions.proto";
 import "uservices_options.proto";
 import "vehicle/body/mirrors/v1/mirrors_properties.proto";
 import "vehicle/body/mirrors/v1/mirrors_topics.proto";

--- a/src/main/proto/vehicle/body/seating/v1/seating_service.proto
+++ b/src/main/proto/vehicle/body/seating/v1/seating_service.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 package vehicle.body.seating.v1;
 
 import "google/rpc/status.proto";
-import "uprotocol_options.proto";
+import "uoptions.proto";
 import "uservices_options.proto";
 import "vehicle/body/seating/v1/seating_topics.proto";
 
@@ -34,10 +34,10 @@ option java_multiple_files = true;
 //
 service Seating {
   // Service metadata option definitions - Name, version, id, rpc method
-  option (uprotocol.name) = "body.seating";
-  option (uprotocol.version_major) = 1;
-  option (uprotocol.version_minor) = 1;
-  option (uprotocol.id) = 23;
+  option (uprotocol.service_name) = "body.seating";
+  option (uprotocol.service_version_major) = 1;
+  option (uprotocol.service_version_minor) = 1;
+  option (uprotocol.service_id) = 23;
 
   // Update position requests for multiple seats and components
   rpc MoveSeats(MoveSeatsRequest) returns (MoveSeatsResponse) {

--- a/src/main/proto/vehicle/body/seating/v1/seating_service.proto
+++ b/src/main/proto/vehicle/body/seating/v1/seating_service.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 package vehicle.body.seating.v1;
 
 import "google/rpc/status.proto";
-import "uoptions.proto";
+import "uprotocol/uoptions.proto";
 import "uservices_options.proto";
 import "vehicle/body/seating/v1/seating_topics.proto";
 

--- a/src/main/proto/vehicle/chassis/braking/v1/braking_service.proto
+++ b/src/main/proto/vehicle/chassis/braking/v1/braking_service.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 package vehicle.chassis.braking.v1;
 
 import "google/rpc/status.proto";
-import "uprotocol_options.proto";
+import "uoptions.proto";
 
 option java_package = "org.covesa.uservice.vehicle.chassis.braking.v1";
 option java_multiple_files = true;
@@ -29,10 +29,10 @@ option java_multiple_files = true;
 //
 service Braking {
   // Service metadata option definitions - Name, version, ID
-  option (uprotocol.name) = "chassis.braking";
-  option (uprotocol.version_major) = 1;
-  option (uprotocol.version_minor) = 0;
-  option (uprotocol.id) = 17;
+  option (uprotocol.service_name) = "chassis.braking";
+  option (uprotocol.service_version_major) = 1;
+  option (uprotocol.service_version_minor) = 0;
+  option (uprotocol.service_id) = 17;
 
   // Used to reset the health status of brake system components such as
   // "brake_pads.front". The reset component's life will then return

--- a/src/main/proto/vehicle/chassis/braking/v1/braking_service.proto
+++ b/src/main/proto/vehicle/chassis/braking/v1/braking_service.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 package vehicle.chassis.braking.v1;
 
 import "google/rpc/status.proto";
-import "uoptions.proto";
+import "uprotocol/uoptions.proto";
 
 option java_package = "org.covesa.uservice.vehicle.chassis.braking.v1";
 option java_multiple_files = true;

--- a/src/main/proto/vehicle/chassis/suspension/v1/suspension_service.proto
+++ b/src/main/proto/vehicle/chassis/suspension/v1/suspension_service.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 package vehicle.chassis.suspension.v1;
 
 import "google/rpc/status.proto";
-import "uoptions.proto";
+import "uprotocol/uoptions.proto";
 import "uservices_options.proto";
 import "vehicle/chassis/suspension/v1/suspension_topics.proto";
 

--- a/src/main/proto/vehicle/chassis/suspension/v1/suspension_service.proto
+++ b/src/main/proto/vehicle/chassis/suspension/v1/suspension_service.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 package vehicle.chassis.suspension.v1;
 
 import "google/rpc/status.proto";
-import "uprotocol_options.proto";
+import "uoptions.proto";
 import "uservices_options.proto";
 import "vehicle/chassis/suspension/v1/suspension_topics.proto";
 
@@ -32,10 +32,10 @@ option java_multiple_files = true;
 //
 service Suspension {
   // Service metadata option definitions - Name, version, ID, RPC method
-  option (uprotocol.name) = "chassis.suspension";
-  option (uprotocol.version_major) = 1;
-  option (uprotocol.version_minor) = 0;
-  option (uprotocol.id) = 21;
+  option (uprotocol.service_name) = "chassis.suspension";
+  option (uprotocol.service_version_major) = 1;
+  option (uprotocol.service_version_minor) = 0;
+  option (uprotocol.service_id) = 21;
 
   // Request to change the vehicle ride height.
   rpc SetRideHeight(SetRideHeightRequest) returns (SetRideHeightResponse) {

--- a/src/main/proto/vehicle/chassis/v1/chassis_service.proto
+++ b/src/main/proto/vehicle/chassis/v1/chassis_service.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 package vehicle.chassis.v1;
 
 import "google/rpc/status.proto";
-import "uprotocol_options.proto";
+import "uoptions.proto";
 import "uservices_options.proto";
 
 option java_package = "org.covesa.uservice.vehicle.chassis.v1";
@@ -28,10 +28,10 @@ option java_multiple_files = true;
 //
 service Chassis {
   // Service metadata option definitions - Name, version, id, rpc method
-  option (uprotocol.name) = "chassis";
-  option (uprotocol.version_major) = 1;
-  option (uprotocol.version_minor) = 0;
-  option (uprotocol.id) = 20;
+  option (uprotocol.service_name) = "chassis";
+  option (uprotocol.service_version_major) = 1;
+  option (uprotocol.service_version_minor) = 0;
+  option (uprotocol.service_id) = 20;
 
   // Send request to update a tire resource
   rpc UpdateTire(UpdateTireRequest) returns (google.rpc.Status) {

--- a/src/main/proto/vehicle/chassis/v1/chassis_service.proto
+++ b/src/main/proto/vehicle/chassis/v1/chassis_service.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 package vehicle.chassis.v1;
 
 import "google/rpc/status.proto";
-import "uoptions.proto";
+import "uprotocol/uoptions.proto";
 import "uservices_options.proto";
 
 option java_package = "org.covesa.uservice.vehicle.chassis.v1";

--- a/src/main/proto/vehicle/exterior/v1/exterior_service.proto
+++ b/src/main/proto/vehicle/exterior/v1/exterior_service.proto
@@ -17,7 +17,7 @@ syntax = "proto3";
 
 package vehicle.exterior.v1;
 
-import "uoptions.proto";
+import "uprotocol/uoptions.proto";
 
 option java_package = "org.covesa.uservice.vehicle.exterior.v1";
 option java_multiple_files = true;

--- a/src/main/proto/vehicle/exterior/v1/exterior_service.proto
+++ b/src/main/proto/vehicle/exterior/v1/exterior_service.proto
@@ -17,7 +17,7 @@ syntax = "proto3";
 
 package vehicle.exterior.v1;
 
-import "uprotocol_options.proto";
+import "uoptions.proto";
 
 option java_package = "org.covesa.uservice.vehicle.exterior.v1";
 option java_multiple_files = true;
@@ -29,10 +29,10 @@ option java_multiple_files = true;
 //
 service VehicleExterior {
   // Service Metadata - Name, version, id, rpc methods
-  option (uprotocol.name) = "vehicle.exterior";
-  option (uprotocol.version_major) = 1;
-  option (uprotocol.version_minor) = 0;
-  option (uprotocol.id) = 16;
+  option (uprotocol.service_name) = "vehicle.exterior";
+  option (uprotocol.service_version_major) = 1;
+  option (uprotocol.service_version_minor) = 0;
+  option (uprotocol.service_id) = 16;
 
   option (uprotocol.publish_topic) = {
     id : 0x8000,

--- a/src/main/proto/vehicle/propulsion/engine/v1/engine_service.proto
+++ b/src/main/proto/vehicle/propulsion/engine/v1/engine_service.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 package vehicle.propulsion.engine.v1;
 
 import "google/rpc/status.proto";
-import "uprotocol_options.proto";
+import "uoptions.proto";
 
 option java_package = "org.covesa.uservice.vehicle.propulsion.engine.v1";
 option java_multiple_files = true;
@@ -29,10 +29,10 @@ option java_multiple_files = true;
 //
 service Engine {
   // Service Metadata - Name, version, id, rpc methods
-  option (uprotocol.name) = "propulsion.engine";
-  option (uprotocol.version_major) = 1;
-  option (uprotocol.version_minor) = 0;
-  option (uprotocol.id) = 19;
+  option (uprotocol.service_name) = "propulsion.engine";
+  option (uprotocol.service_version_major) = 1;
+  option (uprotocol.service_version_minor) = 0;
+  option (uprotocol.service_id) = 19;
 
   // Request to reset an engine component's life to 100%. After a reset, the
   // remaining life will go back to 100% and the health state of that component

--- a/src/main/proto/vehicle/propulsion/engine/v1/engine_service.proto
+++ b/src/main/proto/vehicle/propulsion/engine/v1/engine_service.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 package vehicle.propulsion.engine.v1;
 
 import "google/rpc/status.proto";
-import "uoptions.proto";
+import "uprotocol/uoptions.proto";
 
 option java_package = "org.covesa.uservice.vehicle.propulsion.engine.v1";
 option java_multiple_files = true;

--- a/src/main/proto/vehicle/propulsion/transmission/v1/transmission_service.proto
+++ b/src/main/proto/vehicle/propulsion/transmission/v1/transmission_service.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 
 package vehicle.propulsion.transmission.v1;
 
-import "uprotocol_options.proto";
+import "uoptions.proto";
 
 option java_package = "org.covesa.uservice.vehicle.propulsion.transmission.v1";
 option java_multiple_files = true;
@@ -28,10 +28,10 @@ option java_multiple_files = true;
 //
 service Transmission {
   // Service Metadata - Name, version, ID, RPC methods
-  option (uprotocol.name) = "propulsion.transmission";
-  option (uprotocol.version_major) = 1;
-  option (uprotocol.version_minor) = 0;
-  option (uprotocol.id) = 18;
+  option (uprotocol.service_name) = "propulsion.transmission";
+  option (uprotocol.service_version_major) = 1;
+  option (uprotocol.service_version_minor) = 0;
+  option (uprotocol.service_id) = 18;
 
   option (uprotocol.publish_topic) = {
     id : 0x8000,

--- a/src/main/proto/vehicle/propulsion/transmission/v1/transmission_service.proto
+++ b/src/main/proto/vehicle/propulsion/transmission/v1/transmission_service.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 
 package vehicle.propulsion.transmission.v1;
 
-import "uoptions.proto";
+import "uprotocol/uoptions.proto";
 
 option java_package = "org.covesa.uservice.vehicle.propulsion.transmission.v1";
 option java_multiple_files = true;

--- a/src/main/proto/vehicle/v1/vehicle_service.proto
+++ b/src/main/proto/vehicle/v1/vehicle_service.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 package vehicle.v1;
 
 import "google/rpc/status.proto";
-import "uoptions.proto";
+import "uprotocol/uoptions.proto";
 import "vehicle/v1/vehicle_topics.proto";
 
 option java_package = "org.covesa.uservice.vehicle.v1";

--- a/src/main/proto/vehicle/v1/vehicle_service.proto
+++ b/src/main/proto/vehicle/v1/vehicle_service.proto
@@ -19,7 +19,7 @@ syntax = "proto3";
 package vehicle.v1;
 
 import "google/rpc/status.proto";
-import "uprotocol_options.proto";
+import "uoptions.proto";
 import "vehicle/v1/vehicle_topics.proto";
 
 option java_package = "org.covesa.uservice.vehicle.v1";
@@ -37,10 +37,10 @@ option java_multiple_files = true;
 //
 service Vehicle {
   // Service Metadata - Name, version, ID, RPC methods
-  option (uprotocol.name) = "vehicle";
-  option (uprotocol.version_major) = 1;
-  option (uprotocol.version_minor) = 0;
-  option (uprotocol.id) = 14;
+  option (uprotocol.service_name) = "vehicle";
+  option (uprotocol.service_version_major) = 1;
+  option (uprotocol.service_version_minor) = 0;
+  option (uprotocol.service_id) = 14;
 
   // Request to reset the trip odometer to default value of 0 kilometers.
   rpc ResetTripMeter(ResetTripMeterRequest) returns (google.rpc.Status) {


### PR DESCRIPTION
Modifies the uservices to align with uoptions.proto changes to prepend name, id, version_major, and version_minor with "service_"